### PR TITLE
Added more bi-directional control characters

### DIFF
--- a/html5-validation-engine.js
+++ b/html5-validation-engine.js
@@ -45,7 +45,11 @@
                 /\u00ba/, // Matches that weird symbol europeans use for NO. (º)
                 /\u2010-\u2015/, // Matches the weird dashes (‐ — and everything in between)
                 /\uff03/, // Matches the weird hash tag (＃)
-                /\u202a\u202b\u202c/, // Matches foreign-language directional formatting chars (rtl, ltr, pop directional)
+                // See here for bi-directional text control characters:
+                // https://en.wikipedia.org/wiki/Bi-directional_text#explicit_formatting
+                /\u202a-\u202e/, // Matches foreign-language directional formatting chars (rtl, ltr, pop)
+                /\u2066-\u2069/, // Matches isolated foreign-language direction formatting chars (lri, rli, fsi, pop)
+                /\u200e\u200f\u061c/, // Matches foreign language marks (lrm, rlm, alm for arabic)
             ];
 
             var combinedSource = '';


### PR DESCRIPTION
Increased coverage by a few tenths of a percentage point over the last 3 years.

New pattern:

``` regex
/^[a-zA-Z0-9'\.,-\/#!@$%\^&\*;:{}=\-_+`~()\|\\\/(){}\[\]\s\u200A\u2009\u20a0\u2008\u2002\u2007\u3000\u2003\u2004\u2005\u2006\u00C0-\u00ff\uff0b\uff08\uff09\uff0c\u00e6\u00ba\u2010-\u2015\uff03\u202a-\u202e\u2066-\u2069\u200e\u200f\u061c]*$/
```
