### PR TITLE
CR-65 Fix IE7 source attribute failing

### DIFF
--- a/html5-validation-engine.js
+++ b/html5-validation-engine.js
@@ -55,6 +55,7 @@
             var combinedSource = '';
 
             for (var i = 0; i < regexArray.length; i++) {
+                regexArray[i] = new RegExp(regexArray[i]);
                 combinedSource += regexArray[i].source;
             }
 


### PR DESCRIPTION
combinedSource does not have the native RegExp prototype functions in IE7 until instantiated
