### PR TITLE
JAPAN-461: Moved latin-only regex applicator

### DIFF
--- a/html5-validation-engine.js
+++ b/html5-validation-engine.js
@@ -90,7 +90,7 @@
                     $("form").attr("novalidate", true);
                     var valid = true,
                         $form = $(this).closest("form");
-                    
+
                     if($form.find('.error').length > 0 || !self.checkIfValid($form)){
                         e.stopPropagation();
                         e.stopImmediatePropagation();
@@ -101,11 +101,11 @@
                     return valid;
                 });
             }
-        
+
             this.$el.on("blur", ":input:not(.placeholder)", function(){
                 var $el = $(this);
                 if ($el.attr("data-no-error-onblur")) { return; }
-                
+
                 if(!self.checkInput($el)){
                     $("#error_"+$el.attr("id")).empty();
                     $el.next(".error:first").remove();
@@ -116,7 +116,7 @@
                     $el.trigger('invalid');
                 }
             });
-            
+
             this.$el.on("change", "[type=checkbox],[type=radio]", function(){
                 var $el = $(this);
                 if(!self.checkInput($el)){
@@ -155,7 +155,7 @@
             });
         },
         submitEvent : function(){
-            
+
         },
         blurEvent: function(){
 
@@ -172,7 +172,6 @@
             return isValid;
         },
         checkInput : function ($el) {
-            this.applyAdditionalPatterns($el);
             if($el.attr('required') || $el.attr('type') === 'radio'){
 
                 return this.getErrortype($el);
@@ -183,10 +182,12 @@
                 }else{
                     return false;
                 }
-                
+
             }
         },
         getErrortype: function($input){
+            this.applyAdditionalPatterns($input);
+
             var error = false;
 
             if ($input[0].tagName === 'SELECT' || $input.attr('type') === 'radio' || $input.attr('type') === 'checkbox') {
@@ -195,7 +196,7 @@
             else if(this.getErrortypeFallback($input) || this.getErrorCustom($input)){
                 error = true;
             }
-  
+
             if(error){
                 this.showError($input);
             }
@@ -213,7 +214,7 @@
             else if ($input.attr('validate')) {
                 return !$input[0].checkValidity();
             }
-            
+
             //var isNotValid = !$.trim($input.val());
             return false;
         },
@@ -237,14 +238,14 @@
                     type:"required",
                     isNotValid : true
                 };
-                
+
             } else if(inputType === "number" || inputType === "tel" || inputType === "text" || inputType === "password" || inputType === "date"){
                 error = this.validate.text($input);
                 if (error.isNotValid) {
                     this._state.currentErrorType = error.type;
                 };
             }
-           
+
             return error.isNotValid;
         },
         getErrorCustom : function($input){
@@ -288,7 +289,7 @@
             if (this._state.currentErrorType == 'characterRestriction') {
                 message = $input.data('character-restriction-error-message');
             }
-            
+
 
             var content = "<div class='error'>"+message+"</div>";
 
@@ -303,7 +304,7 @@
             }
 
             $input.addClass('validation-error');
-            
+
         },
         destroy : function(){
             $(document).off("invalid", this.loadHtml5Validation);


### PR DESCRIPTION
Before it was only called on events triggered by form fields, but not the form events
itself (like submit/click). In the event that a user had form fields pre-populated, this
would break validation because latin-only RegEx would not be checked.
